### PR TITLE
Update the worker to make it more generic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
             platforms: 'linux/amd64'
             package: 'src'
-            name: 'rhc-worker-${{ steps.tagName.outputs.tag }}'
+            name: 'rhc-worker-script-${{ steps.tagName.outputs.tag }}'
             compress: 'true'
             dest: 'dist'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
             platforms: 'linux/amd64'
             package: 'src'
-            name: 'rhc-worker-bash-${{ steps.tagName.outputs.tag }}'
+            name: 'rhc-worker-${{ steps.tagName.outputs.tag }}'
             compress: 'true'
             dest: 'dist'
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,7 @@
-specfile_path: packaging/rhc-worker.spec
-upstream_package_name: rhc-worker
-downstream_package_name: rhc-worker
-upstream_project_url: https://github.com/oamg/rhc-worker
+specfile_path: packaging/rhc-worker-script.spec
+upstream_package_name: rhc-worker-script
+downstream_package_name: rhc-worker-script
+upstream_project_url: https://github.com/oamg/rhc-worker-script
 
 srpm_build_deps: [golang, make]
 
@@ -10,22 +10,22 @@ jobs:
 - job: copr_build
   enable_net: true
   owner: "@oamg"
-  project: "rhc-worker"
+  project: "rhc-worker-script"
   targets:
     - epel-7-x86_64
   trigger: pull_request
   actions:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
-      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker.spec
+      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker-script.spec
     create-archive:
       - "make distribution-tarball"
-      - bash -c "ls -1 ./rhc-worker-*.tar.gz"
+      - bash -c "ls -1 ./rhc-worker-script-*.tar.gz"
 
 - job: copr_build
   enable_net: true
   owner: "@oamg"
-  project: "rhc-worker"
+  project: "rhc-worker-script"
   targets:
     - epel-7-x86_64
   trigger: commit
@@ -34,11 +34,11 @@ jobs:
     # bump spec so we get release starting with 2 and hence all the default branch builds will
     # have higher NVR than all the PR builds
     post-upstream-clone:
-      - rpmdev-bumpspec --comment='latest upstream build' ./packaging/rhc-worker.spec
+      - rpmdev-bumpspec --comment='latest upstream build' ./packaging/rhc-worker-script.spec
 
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
-      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker.spec
+      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker-script.spec
     create-archive:
       - "make distribution-tarball"
-      - bash -c "ls -1 ./rhc-worker-*.tar.gz"
+      - bash -c "ls -1 ./rhc-worker-script-*.tar.gz"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,7 @@
-specfile_path: packaging/rhc-worker-bash.spec
-upstream_package_name: rhc-worker-bash
-downstream_package_name: rhc-worker-bash
-upstream_project_url: https://github.com/oamg/rhc-worker-bash
+specfile_path: packaging/rhc-worker.spec
+upstream_package_name: rhc-worker
+downstream_package_name: rhc-worker
+upstream_project_url: https://github.com/oamg/rhc-worker
 
 srpm_build_deps: [golang, make]
 
@@ -10,22 +10,22 @@ jobs:
 - job: copr_build
   enable_net: true
   owner: "@oamg"
-  project: "rhc-worker-bash"
+  project: "rhc-worker"
   targets:
     - epel-7-x86_64
   trigger: pull_request
   actions:
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
-      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker-bash.spec
+      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker.spec
     create-archive:
       - "make distribution-tarball"
-      - bash -c "ls -1 ./rhc-worker-bash-*.tar.gz"
+      - bash -c "ls -1 ./rhc-worker-*.tar.gz"
 
 - job: copr_build
   enable_net: true
   owner: "@oamg"
-  project: "rhc-worker-bash"
+  project: "rhc-worker"
   targets:
     - epel-7-x86_64
   trigger: commit
@@ -34,11 +34,11 @@ jobs:
     # bump spec so we get release starting with 2 and hence all the default branch builds will
     # have higher NVR than all the PR builds
     post-upstream-clone:
-      - rpmdev-bumpspec --comment='latest upstream build' ./packaging/rhc-worker-bash.spec
+      - rpmdev-bumpspec --comment='latest upstream build' ./packaging/rhc-worker.spec
 
     # do not get the version from a tag (git describe) but from the spec file
     get-current-version:
-      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker-bash.spec
+      - grep -oP '^Version:\s+\K\S+' packaging/rhc-worker.spec
     create-archive:
       - "make distribution-tarball"
-      - bash -c "ls -1 ./rhc-worker-bash-*.tar.gz"
+      - bash -c "ls -1 ./rhc-worker-*.tar.gz"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ can run a series of pre-defined hooks against our codebase to keep it clean and
 maintainable. Here is an example of output from `pre-commit` being run:
 
 ```
-(.venv3) [rhc-worker]$ pre-commit run --all-files
+(.venv3) [rhc-worker-script]$ pre-commit run --all-files
 golangci-lint............................................................Passed
 fix end of files.........................................................Passed
 trim trailing whitespace.................................................Passed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ can run a series of pre-defined hooks against our codebase to keep it clean and
 maintainable. Here is an example of output from `pre-commit` being run:
 
 ```
-(.venv3) [rhc-worker-bash]$ pre-commit run --all-files
+(.venv3) [rhc-worker]$ pre-commit run --all-files
 golangci-lint............................................................Passed
 fix end of files.........................................................Passed
 trim trailing whitespace.................................................Passed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to RHC Worker Bash
+# Contributing to RHC Worker Script
 
-The following is a set of guidelines for contributing to RHC Worker Bash codebase,
+The following is a set of guidelines for contributing to RHC Worker Script codebase,
 which are hosted in the [OAMG Organization](https://github.com/oamg) on GitHub.
 These are mostly guidelines, not rules.
 
@@ -144,7 +144,7 @@ pre-commit](https://pre-commit.com/#usage).
 ### Writing tests
 
 Tests are an important part of the development process, they guarantee to us
-that our code is working in the correct way as expected, and for RHC Worker Bash,
+that our code is working in the correct way as expected, and for RHC Worker Script,
 we separate these tests in two categories.
 
 - Unit testing

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 # Project constants
 VERSION ?= 0.2
-PKGNAME ?= rhc-worker-bash
+PKGNAME ?= rhc-worker
 GO_SOURCES := $(wildcard src/*.go)
 PYTHON ?= python3
 PIP ?= pip3
@@ -45,7 +45,7 @@ clean:
 
 build: $(GO_SOURCES)
 	mkdir -p build
-	CGO_ENABLED=0 go build -o build/rhc-bash-worker $^
+	CGO_ENABLED=0 go build -o build/rhc-worker $^
 
 distribution-tarball:
 	go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 # Project constants
 VERSION ?= 0.2
-PKGNAME ?= rhc-worker
+PKGNAME ?= rhc-worker-script
 GO_SOURCES := $(wildcard src/*.go)
 PYTHON ?= python3
 PIP ?= pip3
@@ -45,7 +45,7 @@ clean:
 
 build: $(GO_SOURCES)
 	mkdir -p build
-	CGO_ENABLED=0 go build -o build/rhc-worker $^
+	CGO_ENABLED=0 go build -o build/rhc-worker-script $^
 
 distribution-tarball:
 	go mod vendor

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Tests](https://github.com/oamg/rhc-worker/actions/workflows/tests.yml/badge.svg)
 [![codecov](https://codecov.io/github/oamg/rhc-worker/branch/main/graph/badge.svg?token=6MRLOJS2SJ)](https://codecov.io/github/oamg/rhc-worker)
 
-# RHC Worker Bash
+# RHC Worker
 
-Remote Host Configuration (rhc) worker for executing bash scripts on hosts
-managed by Red Hat Insights.
+Remote Host Configuration (rhc) worker for executing  scripts on hosts
+managed by Red Hat Insights. Interpreter used to execute the script is defined inside the supplied yaml file - served by insights.
 
 - [RHC Worker Bash](#rhc-worker)
   - [General workflow of the worker](#general-workflow-of-the-worker)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-![Tests](https://github.com/oamg/rhc-worker/actions/workflows/tests.yml/badge.svg)
-[![codecov](https://codecov.io/github/oamg/rhc-worker/branch/main/graph/badge.svg?token=6MRLOJS2SJ)](https://codecov.io/github/oamg/rhc-worker)
+![Tests](https://github.com/oamg/rhc-worker-script/actions/workflows/tests.yml/badge.svg)
+[![codecov](https://codecov.io/github/oamg/rhc-worker-script/branch/main/graph/badge.svg?token=6MRLOJS2SJ)](https://codecov.io/github/oamg/rhc-worker-script)
 
 # RHC Worker
 
 Remote Host Configuration (rhc) worker for executing  scripts on hosts
 managed by Red Hat Insights. Interpreter used to execute the script is defined inside the supplied yaml file - served by insights.
 
-- [RHC Worker Bash](#rhc-worker)
+- [RHC Worker Bash](#rhc-worker-script)
   - [General workflow of the worker](#general-workflow-of-the-worker)
   - [Getting started with local development](#getting-started-with-local-development)
     - [Publish first message](#publish-first-message)
@@ -14,9 +14,9 @@ managed by Red Hat Insights. Interpreter used to execute the script is defined i
       - [Custom playbook](#custom-playbook)
       - [Convert2RHEL Playbook](#convert2rhel-playbook)
   - [FAQ](#faq)
-    - [Are there special environment variables used by `rhc-worker`?](#are-there-special-environment-variables-used-by-rhc-worker)
-    - [Can I change behavior of `rhc-worker`?](#can-i-change-behavior-of-rhc-worker)
-    - [Can I change the location of `rhc-worker` config?](#can-i-change-the-location-of-rhc-worker-config)
+    - [Are there special environment variables used by `rhc-worker-script`?](#are-there-special-environment-variables-used-by-rhc-worker-script)
+    - [Can I change behavior of `rhc-worker-script`?](#can-i-change-behavior-of-rhc-worker-script)
+    - [Can I change the location of `rhc-worker-script` config?](#can-i-change-the-location-of-rhc-worker-script-config)
   - [Contact](#contact)
     - [Package maintainers](#package-maintainers)
 
@@ -84,18 +84,18 @@ vagrant ssh -- -t 'rhcd --log-level trace \
 ### Worker playbooks
 
 There is an [example bash playbook](
-https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_bash.yaml)
+https://github.com/oamg/rhc-worker-script/blob/main/development/nginx/data/example_bash.yaml)
 available under `development/nginx/data`, with a minimal bash script to use
 during the worker execution.
 
 If there's a need to test any other playbook provided in this repository, one
 must change what playbook will be used during the message consumption in the
-[mqtt_publish.py](https://github.com/oamg/rhc-worker/blob/main/development/python/mqtt_publish.py#L22)
+[mqtt_publish.py](https://github.com/oamg/rhc-worker-script/blob/main/development/python/mqtt_publish.py#L22)
 file with the name that corresponds the ones present in `development/nginx/data`. Currently, the ones available are:
 
-1. [example_bash.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_bash.yaml)
-2. [example_python.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_python.yaml)
-3. [convert2rhel.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/convert2rhel.yaml)
+1. [example_bash.yaml](https://github.com/oamg/rhc-worker-script/blob/main/development/nginx/data/example_bash.yaml)
+2. [example_python.yaml](https://github.com/oamg/rhc-worker-script/blob/main/development/nginx/data/example_python.yaml)
+3. [convert2rhel.yaml](https://github.com/oamg/rhc-worker-script/blob/main/development/nginx/data/convert2rhel.yaml)
 
 #### Custom playbook
 
@@ -113,23 +113,23 @@ A specialized [Convert2RHEL](https://github.com/oamg/convert2rhel) playbook can 
 
 ## FAQ
 
-### Are there special environment variables used by `rhc-worker`?
+### Are there special environment variables used by `rhc-worker-script`?
 
 There is one special variable that must be set in order to run our worker and that is `YGG_SOCKET_ADDR`, this variable value is set by `rhcd` via `--socket-addr` option.
 
 Other than that there are no special variables, however if downloaded yaml file contained `content_vars` (like the example above), then before the execution of the bash script (`content`) all such variables are set as environment variables and prefixed with `RHC_WORKER_`, after script execution is done they are unset.
 
-### Can I change behavior of `rhc-worker`?
+### Can I change behavior of `rhc-worker-script`?
 
-Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker.yml`, **the config must have valid yaml format**, see all available fields below.
+Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker-script.yml`, **the config must have valid yaml format**, see all available fields below.
 
 Example of full config (with default values):
 
 ```yaml
-# rhc-worker configuration
+# rhc-worker-script configuration
 
 # recipient directive to register with dispatcher
-directive: "rhc-worker"
+directive: "rhc-worker-script"
 
 # whether to verify incoming yaml files
 verify_yaml: true
@@ -138,10 +138,10 @@ verify_yaml: true
 insights_core_gpg_check: true
 
 # temporary directory in which the temporary files with executed bash scripts are created
-temporary_worker_directory: "/var/lib/rhc-worker"
+temporary_worker_directory: "/var/lib/rhc-worker-script"
 ```
 
-### Can I change the location of `rhc-worker` config?
+### Can I change the location of `rhc-worker-script` config?
 
 No, not right now. If you want this feature please create an issue or upvote already existing issue.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Remote Host Configuration (rhc) worker for executing  scripts on hosts
 managed by Red Hat Insights. Interpreter used to execute the script is defined inside the supplied yaml file - served by insights.
 
-- [RHC Worker Bash](#rhc-worker-script)
+- [RHC Worker Script](#rhc-worker-script)
   - [General workflow of the worker](#general-workflow-of-the-worker)
   - [Getting started with local development](#getting-started-with-local-development)
     - [Publish first message](#publish-first-message)
@@ -18,7 +18,7 @@ managed by Red Hat Insights. Interpreter used to execute the script is defined i
     - [Can I change behavior of `rhc-worker-script`?](#can-i-change-behavior-of-rhc-worker-script)
     - [Can I change the location of `rhc-worker-script` config?](#can-i-change-the-location-of-rhc-worker-script-config)
   - [Contact](#contact)
-    - [Package maintainers](#package-maintainers)
+    - [Package maintainers](#package-fmaintainers)
 
 ## General workflow of the worker
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-![Tests](https://github.com/oamg/rhc-worker-bash/actions/workflows/tests.yml/badge.svg)
-[![codecov](https://codecov.io/github/oamg/rhc-worker-bash/branch/main/graph/badge.svg?token=6MRLOJS2SJ)](https://codecov.io/github/oamg/rhc-worker-bash)
+![Tests](https://github.com/oamg/rhc-worker/actions/workflows/tests.yml/badge.svg)
+[![codecov](https://codecov.io/github/oamg/rhc-worker/branch/main/graph/badge.svg?token=6MRLOJS2SJ)](https://codecov.io/github/oamg/rhc-worker)
 
 # RHC Worker Bash
 
 Remote Host Configuration (rhc) worker for executing bash scripts on hosts
 managed by Red Hat Insights.
 
-- [RHC Worker Bash](#rhc-worker-bash)
+- [RHC Worker Bash](#rhc-worker)
   - [General workflow of the worker](#general-workflow-of-the-worker)
   - [Getting started with local development](#getting-started-with-local-development)
     - [Publish first message](#publish-first-message)
@@ -14,9 +14,9 @@ managed by Red Hat Insights.
       - [Custom playbook](#custom-playbook)
       - [Convert2RHEL Playbook](#convert2rhel-playbook)
   - [FAQ](#faq)
-    - [Are there special environment variables used by `rhc-worker-bash`?](#are-there-special-environment-variables-used-by-rhc-worker-bash)
-    - [Can I change behavior of `rhc-worker-bash`?](#can-i-change-behavior-of-rhc-worker-bash)
-    - [Can I change the location of `rhc-worker-bash` config?](#can-i-change-the-location-of-rhc-worker-bash-config)
+    - [Are there special environment variables used by `rhc-worker`?](#are-there-special-environment-variables-used-by-rhc-worker)
+    - [Can I change behavior of `rhc-worker`?](#can-i-change-behavior-of-rhc-worker)
+    - [Can I change the location of `rhc-worker` config?](#can-i-change-the-location-of-rhc-worker-config)
   - [Contact](#contact)
     - [Package maintainers](#package-maintainers)
 
@@ -83,18 +83,19 @@ vagrant ssh -- -t 'rhcd --log-level trace \
 
 ### Worker playbooks
 
-There is an [example playbook](
-https://github.com/oamg/rhc-worker-bash/blob/main/development/nginx/data/example.yaml)
+There is an [example bash playbook](
+https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_bash.yaml)
 available under `development/nginx/data`, with a minimal bash script to use
 during the worker execution.
 
 If there's a need to test any other playbook provided in this repository, one
 must change what playbook will be used during the message consumption in the
-[mqtt_publish.py](https://github.com/oamg/rhc-worker-bash/blob/main/development/python/mqtt_publish.py#L22)
+[mqtt_publish.py](https://github.com/oamg/rhc-worker/blob/main/development/python/mqtt_publish.py#L22)
 file with the name that corresponds the ones present in `development/nginx/data`. Currently, the ones available are:
 
-1. [example.yaml](https://github.com/oamg/rhc-worker-bash/blob/main/development/nginx/data/example.yaml)
-2. [convert2rhel.yaml](https://github.com/oamg/rhc-worker-bash/blob/main/development/nginx/data/convert2rhel.yaml)
+1. [example_bash.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_bash.yaml)
+2. [example_python.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/example_python.yaml)
+3. [convert2rhel.yaml](https://github.com/oamg/rhc-worker/blob/main/development/nginx/data/convert2rhel.yaml)
 
 #### Custom playbook
 
@@ -112,23 +113,23 @@ A specialized [Convert2RHEL](https://github.com/oamg/convert2rhel) playbook can 
 
 ## FAQ
 
-### Are there special environment variables used by `rhc-worker-bash`?
+### Are there special environment variables used by `rhc-worker`?
 
 There is one special variable that must be set in order to run our worker and that is `YGG_SOCKET_ADDR`, this variable value is set by `rhcd` via `--socket-addr` option.
 
 Other than that there are no special variables, however if downloaded yaml file contained `content_vars` (like the example above), then before the execution of the bash script (`content`) all such variables are set as environment variables and prefixed with `RHC_WORKER_`, after script execution is done they are unset.
 
-### Can I change behavior of `rhc-worker-bash`?
+### Can I change behavior of `rhc-worker`?
 
-Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker-bash.yml`, **the config must have valid yaml format**, see all available fields below.
+Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker.yml`, **the config must have valid yaml format**, see all available fields below.
 
 Example of full config (with default values):
 
 ```yaml
-# rhc-worker-bash configuration
+# rhc-worker configuration
 
 # recipient directive to register with dispatcher
-directive: "rhc-worker-bash"
+directive: "rhc-worker"
 
 # whether to verify incoming yaml files
 verify_yaml: true
@@ -137,10 +138,10 @@ verify_yaml: true
 insights_core_gpg_check: true
 
 # temporary directory in which the temporary files with executed bash scripts are created
-temporary_worker_directory: "/var/lib/rhc-worker-bash"
+temporary_worker_directory: "/var/lib/rhc-worker"
 ```
 
-### Can I change the location of `rhc-worker-bash` config?
+### Can I change the location of `rhc-worker` config?
 
 No, not right now. If you want this feature please create an issue or upvote already existing issue.
 

--- a/development/nginx/data/example_bash.yml
+++ b/development/nginx/data/example_bash.yml
@@ -4,9 +4,9 @@
     insights_signature: |
       ascii_armored gpg signature
     insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
+    interpreter: /bin/bash
     content: |
-      #!/bin/sh
-      echo "Hello, world!"
+      echo "Hello, world!" > /root/bash.txt
     content_vars:
       # variables that will be handed to the script as environment vars
       # will be prefixed with RHC_WORKER_*

--- a/development/nginx/data/example_python.yml
+++ b/development/nginx/data/example_python.yml
@@ -1,0 +1,20 @@
+- name: Hello World Example
+  vars:
+    # Signature to validate that no one tampered with script
+    insights_signature: |
+      ascii_armored gpg signature
+    insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
+    interpreter: /usr/bin/python
+    content: |
+      def main():
+        print("Hello, Python!")
+
+        with open("/root/python.txt", "w") as handler:
+          handler.write("Hello, Python!")
+
+      main()
+    content_vars:
+      # variables that will be handed to the script as environment vars
+      # will be prefixed with RHC_WORKER_*
+      FOO: bar
+      BAR: foo

--- a/development/python/mqtt_publish.py
+++ b/development/python/mqtt_publish.py
@@ -12,20 +12,20 @@ def get_ip_address():
   return host_ip
 
 # This is changed everytime you refresh the box and register the machine again.
-CLIENT_ID = "26468815-8407-4058-bcc8-6bcb4eae51c1"
+CLIENT_ID = "f7fb5fa0-9580-4c18-9658-f95885cb31b5"
 BROKER = '127.0.0.1'
 BROKER_PORT = 1883
 TOPIC = f"yggdrasil/{CLIENT_ID}/data/in"
 
 # NOTE: currently can be whatever you placed inside devleopment/nginx/data folder
-SERVED_FILENAME = "example.yml"
+SERVED_FILENAME = "example_bash.yml"
 
 MESSAGE = {
   "type": "data",
   "message_id": str(uuid.uuid4()),
   "version": 1,
   "sent": "2021-01-12T14:58:13+00:00", # str(datetime.datetime.now().isoformat()),
-  "directive": 'rhc-worker-bash',
+  "directive": 'rhc-worker',
   "content": f'http://{get_ip_address()}:8000/data/{SERVED_FILENAME}',
   "metadata": {
       "correlation_id": "00000000-0000-0000-0000-000000000000",

--- a/development/python/mqtt_publish.py
+++ b/development/python/mqtt_publish.py
@@ -25,7 +25,7 @@ MESSAGE = {
   "message_id": str(uuid.uuid4()),
   "version": 1,
   "sent": "2021-01-12T14:58:13+00:00", # str(datetime.datetime.now().isoformat()),
-  "directive": 'rhc-worker',
+  "directive": 'rhc-worker-script',
   "content": f'http://{get_ip_address()}:8000/data/{SERVED_FILENAME}',
   "metadata": {
       "correlation_id": "00000000-0000-0000-0000-000000000000",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oamg/rhc-worker-bash
+module github.com/oamg/rhc-worker
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oamg/rhc-worker
+module github.com/oamg/rhc-worker-script
 
 go 1.16
 

--- a/packaging/rhc-worker-script.spec
+++ b/packaging/rhc-worker-script.spec
@@ -4,7 +4,7 @@
 %define debug_package %{nil}
 
 %global repo_orgname oamg
-%global repo_name rhc-worker
+%global repo_name rhc-worker-script
 %global rhc_libexecdir %{_libexecdir}/rhc
 %{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
 %global rhc_worker_conf_dir %{_root_sysconfdir}/rhc/workers
@@ -58,7 +58,7 @@ popd
 
 
 %install
-# Create a temporary directory /var/lib/rhc-worker - used mainly for storing temporary files
+# Create a temporary directory /var/lib/rhc-worker-script - used mainly for storing temporary files
 install -d %{buildroot}%{_sharedstatedir}/%{repo_name}/
 
 install -D -m 755 _gopath/src/%{repo_name}-%{version}/%{repo_name}-%{version} %{buildroot}%{rhc_libexecdir}/%{repo_name}

--- a/packaging/rhc-worker-script.spec
+++ b/packaging/rhc-worker-script.spec
@@ -21,7 +21,7 @@
 Name:           %{repo_name}
 Version:        0.2
 Release:        1%{?dist}
-Summary:        Worker executing bash scripts on hosts managed by Red Hat Insights
+Summary:        Worker executing scripts on hosts managed by Red Hat Insights
 
 License:        GPLv3+
 URL:            https://github.com/%{repo_orgname}/%{repo_name}
@@ -36,7 +36,7 @@ BuildRequires:  golang
 Requires:       rhc
 
 %description
-Remote Host Configuration (rhc) worker for executing bash scripts on hosts
+Remote Host Configuration (rhc) worker for executing scripts on hosts
 managed by Red Hat Insights.
 
 %prep

--- a/packaging/rhc-worker.spec
+++ b/packaging/rhc-worker.spec
@@ -4,8 +4,7 @@
 %define debug_package %{nil}
 
 %global repo_orgname oamg
-%global repo_name rhc-worker-bash
-%global binary_name rhc-bash-worker
+%global repo_name rhc-worker
 %global rhc_libexecdir %{_libexecdir}/rhc
 %{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
 %global rhc_worker_conf_dir %{_root_sysconfdir}/rhc/workers
@@ -45,28 +44,28 @@ managed by Red Hat Insights.
 
 %build
 mkdir -p _gopath/src
-ln -fs $(pwd)/src _gopath/src/%{binary_name}-%{version}
-ln -fs $(pwd)/vendor _gopath/src/%{binary_name}-%{version}/vendor
+ln -fs $(pwd)/src _gopath/src/%{repo_name}-%{version}
+ln -fs $(pwd)/vendor _gopath/src/%{repo_name}-%{version}/vendor
 export GOPATH=$(pwd)/_gopath
-pushd _gopath/src/%{binary_name}-%{version}
+pushd _gopath/src/%{repo_name}-%{version}
 %if %{use_go_toolset_1_16}
 scl enable go-toolset-1.16 -- %{gobuild}
 %else
 %{gobuild}
 %endif
-strip %{binary_name}-%{version}
+strip %{repo_name}-%{version}
 popd
 
 
 %install
-# Create a temporary directory /var/lib/rhc-worker-bash - used mainly for storing temporary files
-install -d %{buildroot}%{_sharedstatedir}/%{binary_name}/
+# Create a temporary directory /var/lib/rhc-worker - used mainly for storing temporary files
+install -d %{buildroot}%{_sharedstatedir}/%{repo_name}/
 
-install -D -m 755 _gopath/src/%{binary_name}-%{version}/%{binary_name}-%{version} %{buildroot}%{rhc_libexecdir}/%{binary_name}
+install -D -m 755 _gopath/src/%{repo_name}-%{version}/%{repo_name}-%{version} %{buildroot}%{rhc_libexecdir}/%{repo_name}
 install -D -d -m 755 %{buildroot}%{rhc_worker_conf_dir}
 
 %files
-%{rhc_libexecdir}/%{binary_name}
+%{rhc_libexecdir}/%{repo_name}
 %license LICENSE
 %doc README.md
 

--- a/rhc-worker.yml
+++ b/rhc-worker.yml
@@ -1,0 +1,11 @@
+# recipient directive to register with dispatcher
+directive: "rhc-worker"
+
+# whether to verify incoming yaml files
+verify_yaml: false
+
+# perform the insights-client GPG check on the insights-core egg
+insights_core_gpg_check: false
+
+# temporary directory in which the temporary script will be placed and executed.
+temporary_worker_directory: "/var/lib/rhc-worker"

--- a/rhc-worker.yml
+++ b/rhc-worker.yml
@@ -1,5 +1,5 @@
 # recipient directive to register with dispatcher
-directive: "rhc-worker"
+directive: "rhc-worker-script"
 
 # whether to verify incoming yaml files
 verify_yaml: false
@@ -8,4 +8,4 @@ verify_yaml: false
 insights_core_gpg_check: false
 
 # temporary directory in which the temporary script will be placed and executed.
-temporary_worker_directory: "/var/lib/rhc-worker"
+temporary_worker_directory: "/var/lib/rhc-worker-script"

--- a/src/fixtures_test.go
+++ b/src/fixtures_test.go
@@ -7,6 +7,7 @@ var ExampleYamlData = []byte(
   vars:
     insights_signature: "ascii_armored gpg signature"
     insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
+    interpreter: /bin/bash
     content: |
         #!/bin/sh
         echo "$RHC_WORKER_FOO $RHC_WORKER_BAR!"

--- a/src/logger.go
+++ b/src/logger.go
@@ -10,7 +10,7 @@ import (
 )
 
 var sosReportFolder = "/etc/sos.extras.d"
-var sosReportFile = "rhc-worker-logs"
+var sosReportFile = "rhc-worker-script-logs"
 
 // SetupLogger sets up the logger for the application and returns the log file.
 // It creates a log folder if it doesn't exist, opens a log file, sets the log level

--- a/src/main.go
+++ b/src/main.go
@@ -14,9 +14,9 @@ import (
 )
 
 // Initialized in main
-const configFilePath = "/etc/rhc/workers/rhc-worker.yml"
-const logDir = "/var/log/rhc-worker"
-const logFileName = "rhc-worker.log"
+const configFilePath = "/etc/rhc/workers/rhc-worker-script.yml"
+const logDir = "/var/log/rhc-worker-script"
+const logFileName = "rhc-worker-script.log"
 
 var yggdDispatchSocketAddr string
 var config *Config
@@ -52,11 +52,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	// Register as a handler of the "rhc-worker" type.
+	// Register as a handler of the "rhc-worker-script" type.
 	r, err := c.Register(
 		ctx,
 		&pb.RegistrationRequest{
-			Handler:         "rhc-worker",
+			Handler:         "rhc-worker-script",
 			Pid:             int64(os.Getpid()),
 			DetachedContent: true,
 		})

--- a/src/main.go
+++ b/src/main.go
@@ -14,9 +14,9 @@ import (
 )
 
 // Initialized in main
-const configFilePath = "/etc/rhc/workers/rhc-worker-bash.yml"
-const logDir = "/var/log/rhc-worker-bash"
-const logFileName = "rhc-worker-bash.log"
+const configFilePath = "/etc/rhc/workers/rhc-worker.yml"
+const logDir = "/var/log/rhc-worker"
+const logFileName = "rhc-worker.log"
 
 var yggdDispatchSocketAddr string
 var config *Config
@@ -52,11 +52,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	// Register as a handler of the "rhc-worker-bash" type.
+	// Register as a handler of the "rhc-worker" type.
 	r, err := c.Register(
 		ctx,
 		&pb.RegistrationRequest{
-			Handler:         "rhc-worker-bash",
+			Handler:         "rhc-worker",
 			Pid:             int64(os.Getpid()),
 			DetachedContent: true,
 		})

--- a/src/runner.go
+++ b/src/runner.go
@@ -89,7 +89,7 @@ func setEnvVariablesForCommand(cmd *exec.Cmd, variables map[string]string) {
 }
 
 // Parses given yaml data.
-// If signature is valid then extracts the bash script to temporary file,
+// If signature is valid then extracts the script to temporary file,
 // sets env variables if present and then runs the script.
 // Return stdout of executed script or error message if the signature wasn't valid.
 func processSignedScript(incomingContent []byte) string {

--- a/src/runner.go
+++ b/src/runner.go
@@ -15,6 +15,7 @@ type signedYamlContentVars struct {
 	InsightsSignature        string            `yaml:"insights_signature"`
 	InsightsSignatureExclude string            `yaml:"insights_signature_exclude"`
 	Content                  string            `yaml:"content"`
+	Interpreter              string            `yaml:"interpreter"`
 	ContentVars              map[string]string `yaml:"content_vars"`
 }
 
@@ -119,16 +120,16 @@ func processSignedScript(incomingContent []byte) string {
 	yamlContent := signedYamlArray[0]
 
 	// Write the file contents to the temporary disk
-	log.Infoln("Writing temporary bash script")
+	log.Infof("Writing temporary script to %s", *config.TemporaryWorkerDirectory)
 	scriptFileName := writeFileToTemporaryDir(
 		[]byte(yamlContent.Vars.Content), *config.TemporaryWorkerDirectory)
 	defer os.Remove(scriptFileName)
 
-	log.Infoln("Processing bash script ...")
+	log.Infoln("Processing script ...")
 
 	// Execute script
-	log.Infoln("Executing bash script...")
-	cmd := exec.Command("/bin/sh", scriptFileName)
+	log.Infoln("Executing script...")
+	cmd := exec.Command(yamlContent.Vars.Interpreter, scriptFileName) //nolint:gosec
 	setEnvVariablesForCommand(cmd, yamlContent.Vars.ContentVars)
 
 	out, err := cmd.Output()
@@ -137,6 +138,6 @@ func processSignedScript(incomingContent []byte) string {
 		return ""
 	}
 
-	log.Infoln("Bash script executed successfully")
+	log.Infoln("Script executed successfully.")
 	return string(out)
 }

--- a/src/server.go
+++ b/src/server.go
@@ -83,12 +83,12 @@ type jobServer struct {
 }
 
 // Send is the implementation of the "Send" method of the Worker gRPC service.
-// It executes a temporary bash script, reads its output, and sends a message
+// It executes a temporary script, reads its output, and sends a message
 // containing the script's result to the Dispatcher service.
 //
 // The function performs the following steps:
 //  1. Writes the contents of the received data to a temporary file on disk.
-//  2. Executes the bash script by calling the appropriate function.
+//  2. Executes the script by calling the appropriate function.
 //  3. Establishes a connection with the Dispatcher service using gRPC.
 //  4. Creates a client of the Dispatcher service.
 //  5. Constructs a data message to send back to the dispatcher.

--- a/src/util.go
+++ b/src/util.go
@@ -24,7 +24,7 @@ func writeFileToTemporaryDir(data []byte, temporaryWorkerDirectory string) strin
 		}
 	}
 
-	file, err := os.CreateTemp(temporaryWorkerDirectory, "rhc-worker-")
+	file, err := os.CreateTemp(temporaryWorkerDirectory, "rhc-worker-script")
 	if err != nil {
 		log.Errorln("Failed to create temporary file: ", err)
 	}
@@ -61,7 +61,7 @@ func getOutputFile(stdout string, correlationID string, contentType string) (*by
 	writer := multipart.NewWriter(body)
 
 	h := make(textproto.MIMEHeader)
-	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", "rhc-worker-output.tar.gz"))
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", "rhc-worker-script-output.tar.gz"))
 	h.Set("Content-Type", contentType)
 
 	part, err := writer.CreatePart(h)
@@ -104,7 +104,7 @@ type Config struct {
 func setDefaultValues(config *Config) {
 	// Set default values for string and boolean fields if they are nil (not present in the YAML)
 	if config.Directive == nil {
-		defaultDirectiveValue := "rhc-worker"
+		defaultDirectiveValue := "rhc-worker-script"
 		config.Directive = &defaultDirectiveValue
 	}
 
@@ -119,7 +119,7 @@ func setDefaultValues(config *Config) {
 	}
 
 	if config.TemporaryWorkerDirectory == nil {
-		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker"
+		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker-script"
 		config.TemporaryWorkerDirectory = &defaultTemporaryWorkerDirectoryValue
 	}
 }
@@ -141,7 +141,7 @@ func loadYAMLConfig(filePath string) *Config {
 }
 
 // Load config from given filepath, if config doesn't exist then default config values are used
-// Directive = rhc-worker
+// Directive = rhc-worker-script
 // VerifyYAML = "1"
 // InsightsCoreGPGCheck = "1"
 func loadConfigOrDefault(filePath string) *Config {

--- a/src/util.go
+++ b/src/util.go
@@ -24,7 +24,7 @@ func writeFileToTemporaryDir(data []byte, temporaryWorkerDirectory string) strin
 		}
 	}
 
-	file, err := os.CreateTemp(temporaryWorkerDirectory, "rhc-worker-bash-")
+	file, err := os.CreateTemp(temporaryWorkerDirectory, "rhc-worker-")
 	if err != nil {
 		log.Errorln("Failed to create temporary file: ", err)
 	}
@@ -61,7 +61,7 @@ func getOutputFile(stdout string, correlationID string, contentType string) (*by
 	writer := multipart.NewWriter(body)
 
 	h := make(textproto.MIMEHeader)
-	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", "rhc-worker-bash-output.tar.gz"))
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", "rhc-worker-output.tar.gz"))
 	h.Set("Content-Type", contentType)
 
 	part, err := writer.CreatePart(h)
@@ -104,7 +104,7 @@ type Config struct {
 func setDefaultValues(config *Config) {
 	// Set default values for string and boolean fields if they are nil (not present in the YAML)
 	if config.Directive == nil {
-		defaultDirectiveValue := "rhc-worker-bash"
+		defaultDirectiveValue := "rhc-worker"
 		config.Directive = &defaultDirectiveValue
 	}
 
@@ -119,7 +119,7 @@ func setDefaultValues(config *Config) {
 	}
 
 	if config.TemporaryWorkerDirectory == nil {
-		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker-bash"
+		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker"
 		config.TemporaryWorkerDirectory = &defaultTemporaryWorkerDirectoryValue
 	}
 }
@@ -141,7 +141,7 @@ func loadYAMLConfig(filePath string) *Config {
 }
 
 // Load config from given filepath, if config doesn't exist then default config values are used
-// Directive = rhc-worker-bash
+// Directive = rhc-worker
 // VerifyYAML = "1"
 // InsightsCoreGPGCheck = "1"
 func loadConfigOrDefault(filePath string) *Config {

--- a/src/util_test.go
+++ b/src/util_test.go
@@ -157,23 +157,23 @@ func boolPtr(b bool) *bool {
 
 // Test YAML data
 const validYAMLData = `
-directive: "rhc-worker"
+directive: "rhc-worker-script"
 verify_yaml: true
 verify_yaml_version_check: true
 insights_core_gpg_check: true
-temporary_worker_directory: "/var/lib/rhc-worker"
+temporary_worker_directory: "/var/lib/rhc-worker-script"
 `
 
 const validYAMLDataMissingValues = `
-directive: "rhc-worker"
+directive: "rhc-worker-script"
 `
 
 func TestLoadConfigOrDefault(t *testing.T) {
 	expectedConfig := &Config{
-		Directive:                strPtr("rhc-worker"),
+		Directive:                strPtr("rhc-worker-script"),
 		VerifyYAML:               boolPtr(true),
 		InsightsCoreGPGCheck:     boolPtr(true),
-		TemporaryWorkerDirectory: strPtr("/var/lib/rhc-worker"),
+		TemporaryWorkerDirectory: strPtr("/var/lib/rhc-worker-script"),
 	}
 
 	testCases := []struct {

--- a/src/util_test.go
+++ b/src/util_test.go
@@ -157,23 +157,23 @@ func boolPtr(b bool) *bool {
 
 // Test YAML data
 const validYAMLData = `
-directive: "rhc-worker-bash"
+directive: "rhc-worker"
 verify_yaml: true
 verify_yaml_version_check: true
 insights_core_gpg_check: true
-temporary_worker_directory: "/var/lib/rhc-worker-bash"
+temporary_worker_directory: "/var/lib/rhc-worker"
 `
 
 const validYAMLDataMissingValues = `
-directive: "rhc-worker-bash"
+directive: "rhc-worker"
 `
 
 func TestLoadConfigOrDefault(t *testing.T) {
 	expectedConfig := &Config{
-		Directive:                strPtr("rhc-worker-bash"),
+		Directive:                strPtr("rhc-worker"),
 		VerifyYAML:               boolPtr(true),
 		InsightsCoreGPGCheck:     boolPtr(true),
-		TemporaryWorkerDirectory: strPtr("/var/lib/rhc-worker-bash"),
+		TemporaryWorkerDirectory: strPtr("/var/lib/rhc-worker"),
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
The idea behind this commit is to make the worker even more generic, not only being able to execute bash scripts, but, let the user decide which type of script it will be executed, by defining a `interpreter` key in the partial yaml playbook, which will tell the worker what to execute.

Changes included in this commit:

* Rename every reference from rhc-worker-bash to rhc-worker
* Added the `interpreter` key to be parsed in the incoming playbook 
** Use the `interpreter` key instead of hardcoding the /bin/bash path
    for the command execution
* Updated the references in the project to build using the new name