### PR TITLE
Update Makefile and playbook examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean:
 
 build: $(GO_SOURCES)
 	mkdir -p build
-	CGO_ENABLED=0 go build -o build/rhc-worker-script $^
+	CGO_ENABLED=0 go build -o build/rhc-script-worker $^
 
 distribution-tarball:
 	go mod vendor

--- a/development/nginx/data/example_bash.yml
+++ b/development/nginx/data/example_bash.yml
@@ -1,4 +1,4 @@
-- name: Hello World Example
+- name: Hello World Bash Example
   vars:
     # Signature to validate that no one tampered with script
     insights_signature: |
@@ -6,6 +6,7 @@
     insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
     interpreter: /bin/bash
     content: |
+      echo "Hello, Bash!"
       echo "Hello, world!" > /root/bash.txt
     content_vars:
       # variables that will be handed to the script as environment vars

--- a/development/nginx/data/example_python.yml
+++ b/development/nginx/data/example_python.yml
@@ -1,4 +1,4 @@
-- name: Hello World Example
+- name: Hello World Python Example
   vars:
     # Signature to validate that no one tampered with script
     insights_signature: |
@@ -10,7 +10,7 @@
         print("Hello, Python!")
 
         with open("/root/python.txt", "w") as handler:
-          handler.write("Hello, Python!")
+          handler.write("Hello, world!")
 
       main()
     content_vars:


### PR DESCRIPTION
The Makefile was using old targets name to build the worker.