### PR TITLE
Change gitleaks to use docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,5 +12,5 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.0
     hooks:
-      - id: gitleaks
+      - id: gitleaks-docker
         stages: [manual, push]


### PR DESCRIPTION
gitleaks installed via go requires newer version (1.17) than our worker does (1.16)