### PR TITLE
Fix/scan issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ distribution-tarball:
 		--exclude=.github \
 		--exclude=.gitignore \
 		--exclude=.copr \
+		--exclude=development \
 		--transform s/^\./$(PKGNAME)-$(VERSION)/ \
 		. && mv /tmp/$(PKGNAME)-$(VERSION).tar.gz .
 	rm -rf ./vendor

--- a/src/main.go
+++ b/src/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	config = loadConfigOrDefault(configFilePath)
 	log.Infoln("Configuration loaded: ", config)
+	defer os.RemoveAll(*config.TemporaryWorkerDirectory)
 
 	logFile := setupLogger(logDir, logFileName)
 	defer logFile.Close()

--- a/src/main.go
+++ b/src/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	config = loadConfigOrDefault(configFilePath)
 	log.Infoln("Configuration loaded: ", config)
-	defer os.RemoveAll(*config.TemporaryWorkerDirectory)
+	defer os.Remove(*config.TemporaryWorkerDirectory)
 
 	logFile := setupLogger(logDir, logFileName)
 	defer logFile.Close()

--- a/src/runner.go
+++ b/src/runner.go
@@ -65,7 +65,10 @@ func verifyYamlFile(yamlData []byte) bool {
 		log.Errorln(err)
 		return false
 	}
-	stdin.Close()
+
+	if err := stdin.Close(); err != nil {
+		log.Errorln("stdin was unexpectedly already closed: ", err)
+	}
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/src/util.go
+++ b/src/util.go
@@ -31,7 +31,9 @@ func writeFileToTemporaryDir(data []byte, temporaryWorkerDirectory string) strin
 	}
 
 	fileName := file.Name()
-	file.Close()
+	if err := file.Close(); err != nil {
+		log.Errorln("File was unexpectedly already closed: ", err)
+	}
 	return fileName
 }
 
@@ -70,7 +72,9 @@ func getOutputFile(stdout string, correlationID string, contentType string) (*by
 		log.Errorln("Failed to write json with script stdout to file: ", err)
 	}
 
-	writer.Close()
+	if err := writer.Close(); err != nil {
+		log.Errorln("Writer was unexpectedly already closed: ", err)
+	}
 
 	log.Infoln("form-data created, returning body: ", body)
 	return body, writer.Boundary()

--- a/src/util.go
+++ b/src/util.go
@@ -17,11 +17,8 @@ import (
 // designated temporary worker directory. It creates the directory if it doesn't exist.
 // The function returns the filename of the created temporary file.
 func writeFileToTemporaryDir(data []byte, temporaryWorkerDirectory string) string {
-	// Check if path exists, if not, create it.
-	if _, err := os.Stat(temporaryWorkerDirectory); err != nil {
-		if err := os.Mkdir(temporaryWorkerDirectory, os.ModePerm); err != nil {
-			log.Errorln("Failed to create temporary directory: ", err)
-		}
+	if err := checkAndCreateDirectory(temporaryWorkerDirectory); err != nil {
+		log.Error("Failed to create temporary directory: ", err)
 	}
 
 	file, err := os.CreateTemp(temporaryWorkerDirectory, "rhc-worker-script")
@@ -163,7 +160,8 @@ func loadConfigOrDefault(filePath string) *Config {
 func checkAndCreateDirectory(folder string) error {
 	// Check if path exists, if not, create it.
 	if _, err := os.Stat(folder); err != nil {
-		if err := os.Mkdir(folder, os.ModePerm); err != nil {
+		// Owner has permission to list, append and search in folder
+		if err := os.Mkdir(folder, 0700); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
[HMS-2552](https://issues.redhat.com/browse/HMS-2552)

- [x] Fix the possible defects that are related to the code itself of the worker
  - explicit permissions set for temporary folder and check added to close calls 
- [x] Fix the defects that are related to the build process
  - development folder excluded from tarball 
- [x] Figure out a way to fix the false positives that comes from the vendor folder
  - Nothing we can do in a code to deal with them, we will either waive them or mark them as fix later (with intention to fix them in upstream) 