### PR TITLE
Update specfile to include config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Other than that there are no special variables, however if downloaded yaml file 
 
 ### Can I change behavior of `rhc-worker-script`?
 
-Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker-script.yml`, **the config must have valid yaml format**, see all available fields below.
+Yes, some values can be changed in the config file located at `/etc/rhc/workers/rhc-worker-script.yml`. After installing the `rhc-worker-script` package, a config file will be created with the default values required for the worker to start processing messages, **the config must have valid yaml format**, see all available fields below.
 
 Example of full config (with default values):
 

--- a/packaging/rhc-worker-script.spec
+++ b/packaging/rhc-worker-script.spec
@@ -65,10 +65,26 @@ install -d %{buildroot}%{_sharedstatedir}/%{binary_name}/
 install -D -m 755 _gopath/src/%{binary_name}-%{version}/%{binary_name}-%{version} %{buildroot}%{rhc_libexecdir}/%{binary_name}
 install -D -d -m 755 %{buildroot}%{rhc_worker_conf_dir}
 
+cat <<EOF >%{buildroot}%{rhc_worker_conf_dir}/rhc-worker-script.yml
+# recipient directive to register with dispatcher
+directive: "%{name}"
+
+# whether to verify incoming yaml files
+verify_yaml: true
+
+# perform the insights-client GPG check on the insights-core egg
+insights_core_gpg_check: true
+
+# temporary directory in which the temporary script will be placed and executed.
+temporary_worker_directory: "/var/lib/rhc-worker-script"
+EOF
+
+
 %files
 %{rhc_libexecdir}/%{binary_name}
 %license LICENSE
 %doc README.md
+%config %{rhc_worker_conf_dir}/rhc-worker-script.yml
 
 %changelog
 


### PR DESCRIPTION
[HMS-2572](https://issues.redhat.com/browse/HMS-2572)

Minimal version of a configuration file is included in the specfile now and it will be generated at the /etc/rhc/workers/ folder.

- [x] when rhc-worker-script is installed on fresh centos system the config with default values is present in /etc/rhc/workers/