### PR TITLE
Improve logging when config file can't be used and default values are used instead

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -21,7 +21,6 @@ func createDataMessage(commandOutput string, metadata map[string]string, directi
 	var data *pb.Data
 	if commandOutput != "" && fileContent != nil {
 		contentType := fmt.Sprintf("multipart/form-data; boundary=%s", boundary)
-		log.Infof("Sending message to %s", messageID)
 		data = &pb.Data{
 			MessageId:  uuid.New().String(),
 			ResponseTo: messageID,
@@ -95,7 +94,6 @@ type jobServer struct {
 //  6. Sends the data message using the "Send" method of the Dispatcher service.
 func (s *jobServer) Send(_ context.Context, d *pb.Data) (*pb.Receipt, error) {
 
-	// Goroutine processing the data, cancels the context when processing is done
 	go func() {
 		data := processData(d)
 		sendDataToDispatcher(data)

--- a/src/util.go
+++ b/src/util.go
@@ -106,21 +106,25 @@ func setDefaultValues(config *Config) {
 	// Set default values for string and boolean fields if they are nil (not present in the YAML)
 	if config.Directive == nil {
 		defaultDirectiveValue := "rhc-worker-script"
+		log.Infof("config 'directive' value is empty default value (%s) will be used", defaultDirectiveValue)
 		config.Directive = &defaultDirectiveValue
 	}
 
 	if config.VerifyYAML == nil {
 		defaultVerifyYamlValue := true
+		log.Infof("config 'verify_yaml' value is empty default value (%t) will be used", defaultVerifyYamlValue)
 		config.VerifyYAML = &defaultVerifyYamlValue
 	}
 
 	if config.InsightsCoreGPGCheck == nil {
 		defaultGpgCheckValue := true
+		log.Infof("config 'insights_core_gpg_check' value is empty default value (%t) will be used", defaultGpgCheckValue)
 		config.InsightsCoreGPGCheck = &defaultGpgCheckValue
 	}
 
 	if config.TemporaryWorkerDirectory == nil {
 		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker-script"
+		log.Infof("config 'temporary_worker_directory' value is empty default value (%s) will be used", defaultTemporaryWorkerDirectoryValue)
 		config.TemporaryWorkerDirectory = &defaultTemporaryWorkerDirectoryValue
 	}
 }


### PR DESCRIPTION
- Removed one log from server.go because same log is called in `sendDataToDispatcher`
- Added info log when default values for config are used.