### PR TITLE
Move the logging init to be before anything else

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -39,7 +39,6 @@ func main() {
 	log.Infoln("Configuration loaded: ", config)
 	defer os.Remove(*config.TemporaryWorkerDirectory)
 
-
 	// Dial the dispatcher on its well-known address.
 	conn, err := grpc.Dial(
 		yggdDispatchSocketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/src/main.go
+++ b/src/main.go
@@ -32,13 +32,13 @@ func main() {
 	if !yggSocketAddrExists {
 		log.Fatal("Missing YGG_SOCKET_ADDR environment variable")
 	}
+	logFile := setupLogger(logDir, logFileName)
+	defer logFile.Close()
 
 	config = loadConfigOrDefault(configFilePath)
 	log.Infoln("Configuration loaded: ", config)
 	defer os.Remove(*config.TemporaryWorkerDirectory)
 
-	logFile := setupLogger(logDir, logFileName)
-	defer logFile.Close()
 
 	// Dial the dispatcher on its well-known address.
 	conn, err := grpc.Dial(


### PR DESCRIPTION
We were losing the first Infoln call because we were setting up the logging after that.