### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,13 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Generate build files
-        uses: thatisuday/go-cross-build@v1.0.2
+      - uses: actions/setup-go@v4
         with:
-            platforms: 'linux/amd64'
-            package: 'src'
-            name: 'rhc-worker-script-${{ steps.tagName.outputs.tag }}'
-            compress: 'true'
-            dest: 'dist'
+          go-version: '1.19'
 
       - name: Generate distribution tarball
         run: |
-          make distribution-tarball
+          mkdir dist && make distribution-tarball
           sudo mv *.tar.gz dist/
         env:
           VERSION: '${{ steps.tagName.outputs.tag }}'


### PR DESCRIPTION
The current release workflow was using golang 1.16 and failing to download and vendor the dependencies, but since the build is not being used during the brew builds, as we generate new ones, the easiest option was to remove that dated workflow and let only the distribution-tarball generate the needed files.