### PR TITLE
Release v0.6 Gojira

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 	coverage-html
 
 # Project constants
-VERSION ?= 0.5
+VERSION ?= 0.6
 PKGNAME ?= rhc-worker-script
 GO_SOURCES := $(wildcard src/*.go)
 PYTHON ?= python3

--- a/packaging/rhc-worker-script.spec
+++ b/packaging/rhc-worker-script.spec
@@ -20,7 +20,7 @@
 %global use_go_toolset_1_19 0%{?rhel} == 7 && !%{defined centos}
 
 Name:           %{repo_name}
-Version:        0.5
+Version:        0.6
 Release:        1%{?dist}
 Summary:        Worker executing scripts on hosts managed by Red Hat Insights
 
@@ -84,6 +84,11 @@ EOF
 %config %{rhc_worker_conf_dir}/rhc-worker-script.yml
 
 %changelog
+
+* Wed Feb 28 2024 Rodolfo Olivieri <rolivier@redhat.com> 0.6-1
+- Fix grpc to newest v1.59.x version
+- Remove insights_core_gpg_check from worker config
+- When script fails with exit code 1 we want to see the reason in logs
 
 * Mon Oct 16 2023 Rodolfo Olivieri <rolivier@redhat.com> 0.5-1
 - Rebuild against newer golang which addresses CVE-2023-39325 and CVE-2023-44487


### PR DESCRIPTION
## What's Changed
* Update SERVED_FILENAME in Makefile by @r0x0d in https://github.com/oamg/rhc-worker-script/pull/98
* Bump actions/checkout from 3 to 4 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/99
* Bump github.com/google/uuid from 1.3.1 to 1.4.0 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/102
* Fix grpc to newest v1.59.x version by @andywaltlova in https://github.com/oamg/rhc-worker-script/pull/101
* Remove insights_core_gpg_check from worker config by @andywaltlova in https://github.com/oamg/rhc-worker-script/pull/104
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/oamg/rhc-worker-script/pull/105
* When script fails with exit code 1 we want to see the reason in logs by @andywaltlova in https://github.com/oamg/rhc-worker-script/pull/106
* Bump actions/setup-go from 4 to 5 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/107
* Bump github.com/google/uuid from 1.4.0 to 1.5.0 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/108
* Bump github/codeql-action from 2 to 3 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/109
* Bump git.sr.ht/~spc/go-log from 0.0.0-20230531172318-1397be06f5f4 to 0.1.1 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/110
* Bump github.com/google/uuid from 1.5.0 to 1.6.0 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/111
* Bump codecov/codecov-action from 3 to 4 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/112
* [pre-commit.ci] pre-commit autoupdate by @pre-commit-ci in https://github.com/oamg/rhc-worker-script/pull/113
* Bump paho-mqtt from 1.6.1 to 2.0.0 in /development/python by @dependabot in https://github.com/oamg/rhc-worker-script/pull/114
* Bump golangci/golangci-lint-action from 3 to 4 by @dependabot in https://github.com/oamg/rhc-worker-script/pull/115


**Full Changelog**: https://github.com/oamg/rhc-worker-script/compare/v0.5...v0.6