### PR TITLE
Load env vars from worker config file into script execution env

### DIFF
--- a/rhc-worker-script.yml
+++ b/rhc-worker-script.yml
@@ -6,3 +6,9 @@ verify_yaml: false
 
 # temporary directory in which the temporary script will be placed and executed.
 temporary_worker_directory: "/var/lib/rhc-worker-script"
+
+env:
+  # environment variables to be set for the script
+  FOO: "some-string-value"
+  BAR: "other-string-value"
+  # ...

--- a/src/fixtures_test.go
+++ b/src/fixtures_test.go
@@ -10,7 +10,7 @@ var ExampleYamlData = []byte(
     interpreter: /bin/bash
     content: |
         #!/bin/sh
-        echo "$RHC_WORKER_FOO $RHC_WORKER_BAR!"
+        echo "$RHC_WORKER_FOO $RHC_WORKER_BAR $RHC_WORKER_NAME!"
     content_vars:
         FOO: Hello
         BAR: World`)

--- a/src/runner.go
+++ b/src/runner.go
@@ -73,7 +73,6 @@ func verifyYamlFile(yamlData []byte) bool {
 }
 
 func setEnvVariablesForCommand(cmd *exec.Cmd, variables map[string]string) {
-	cmd.Env = os.Environ()
 	getEnvVarName := func(key string) string {
 		return fmt.Sprintf("RHC_WORKER_%s", strings.ToUpper(key))
 	}
@@ -125,7 +124,15 @@ func processSignedScript(incomingContent []byte) string {
 	// Execute script
 	log.Infoln("Executing script...")
 	cmd := exec.Command(yamlContent.Vars.Interpreter, scriptFileName) //nolint:gosec
+	cmd.Env = os.Environ()
+
+	// Set env vars from yaml envelope
 	setEnvVariablesForCommand(cmd, yamlContent.Vars.ContentVars)
+
+	// Set env vars from config
+	if config.Env != nil {
+		setEnvVariablesForCommand(cmd, *config.Env)
+	}
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/src/runner_test.go
+++ b/src/runner_test.go
@@ -23,7 +23,7 @@ func TestProcessSignedScript(t *testing.T) {
 			name:           "verification disabled, yaml data supplied = non-empty output",
 			verifyYAML:     false,
 			yamlData:       ExampleYamlData,
-			expectedResult: "Hello World!\n",
+			expectedResult: "Hello World Test!\n",
 		},
 		{
 			name:           "verification enabled, invalid signature = error msg returned",
@@ -37,9 +37,11 @@ func TestProcessSignedScript(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			shouldVerifyYaml := tc.verifyYAML
 			temporaryWorkerDirectory := t.TempDir()
+			envMap := map[string]string{"NAME": "Test"}
 			config = &Config{
 				VerifyYAML:               &shouldVerifyYaml,
 				TemporaryWorkerDirectory: &temporaryWorkerDirectory,
+				Env:                      &envMap,
 			}
 
 			defer os.RemoveAll(temporaryWorkerDirectory)

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -98,7 +98,7 @@ func TestProcessData(t *testing.T) {
 		{
 			name:                  "Expected data are present in result data",
 			yamlData:              ExampleYamlData,
-			expectedOutput:        "Hello World!",
+			expectedOutput:        "Hello World Test!",
 			expectedDirective:     "bar",
 			expectedReturnContent: "foo",
 		},
@@ -117,6 +117,7 @@ func TestProcessData(t *testing.T) {
 			config = &Config{
 				VerifyYAML:               &shouldVerifyYaml,
 				TemporaryWorkerDirectory: &temporaryWorkerDirectory,
+				Env:                      &map[string]string{"NAME": "Test"},
 			}
 
 			returnURL := "bar"

--- a/src/util.go
+++ b/src/util.go
@@ -93,11 +93,12 @@ func constructMetadata(receivedMetadata map[string]string, contentType string) m
 	return ourMetadata
 }
 
-// Struc used fro worker global config
+// Struct used for worker global config
 type Config struct {
-	Directive                *string `yaml:"directive,omitempty"`
-	VerifyYAML               *bool   `yaml:"verify_yaml,omitempty"`
-	TemporaryWorkerDirectory *string `yaml:"temporary_worker_directory,omitempty"`
+	Directive                *string            `yaml:"directive,omitempty"`
+	VerifyYAML               *bool              `yaml:"verify_yaml,omitempty"`
+	TemporaryWorkerDirectory *string            `yaml:"temporary_worker_directory,omitempty"`
+	Env                      *map[string]string `yaml:"env,omitempty"`
 }
 
 // Set default values for the Config struct
@@ -119,6 +120,12 @@ func setDefaultValues(config *Config) {
 		defaultTemporaryWorkerDirectoryValue := "/var/lib/rhc-worker-script"
 		log.Infof("config 'temporary_worker_directory' value is empty default value (%s) will be used", defaultTemporaryWorkerDirectoryValue)
 		config.TemporaryWorkerDirectory = &defaultTemporaryWorkerDirectoryValue
+	}
+
+	if config.Env == nil {
+		defaultEnvMap := map[string]string{}
+		log.Infof("config 'temporary_worker_directory' value is empty default value (%s) will be used", defaultEnvMap)
+		config.Env = &defaultEnvMap
 	}
 }
 

--- a/src/util.go
+++ b/src/util.go
@@ -124,7 +124,7 @@ func setDefaultValues(config *Config) {
 
 	if config.Env == nil {
 		defaultEnvMap := map[string]string{}
-		log.Infof("config 'temporary_worker_directory' value is empty default value (%s) will be used", defaultEnvMap)
+		log.Infof("config 'env' value is empty default value (%s) will be used", defaultEnvMap)
 		config.Env = &defaultEnvMap
 	}
 }

--- a/src/util_test.go
+++ b/src/util_test.go
@@ -154,12 +154,17 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
+func mapStrPtr(m map[string]string) *map[string]string {
+	return &m
+}
+
 // Test YAML data
 const validYAMLData = `
 directive: "rhc-worker-script"
 verify_yaml: true
-verify_yaml_version_check: true
 temporary_worker_directory: "/var/lib/rhc-worker-script"
+env:
+  ENV_VAR1: "value1"
 `
 
 const validYAMLDataMissingValues = `
@@ -171,6 +176,7 @@ func TestLoadConfigOrDefault(t *testing.T) {
 		Directive:                strPtr("rhc-worker-script"),
 		VerifyYAML:               boolPtr(true),
 		TemporaryWorkerDirectory: strPtr("/var/lib/rhc-worker-script"),
+		Env:                      mapStrPtr(map[string]string{"ENV_VAR1": "value1"}),
 	}
 
 	testCases := []struct {
@@ -236,13 +242,13 @@ func TestSetDefaultValues(t *testing.T) {
 	}{
 		{
 			name: "test default values",
-			args: args{config: &Config{nil, nil, nil}},
-			want: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script")}},
+			args: args{config: &Config{nil, nil, nil, nil}},
+			want: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script"), mapStrPtr(map[string]string{})}},
 		},
 		{
 			name: "test non default values",
-			args: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script")}},
-			want: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script")}},
+			args: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script"), mapStrPtr(map[string]string{"ENV_VAR1": "value1"})}},
+			want: args{config: &Config{strPtr("rhc-worker-script"), boolPtr(true), strPtr("/var/lib/rhc-worker-script"), mapStrPtr(map[string]string{"ENV_VAR1": "value1"})}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
[HMS-3843](https://issues.redhat.com/browse/HMS-3843)

This is aimed to give users possibility to pass additional variables to script execution environment through same config as worker uses.

If rhcd passes additional variables then so be it, these will get appended to the execution environment on top of them.