### PR TITLE
Remove SCL conditions from specfile

### DIFF
--- a/packaging/rhc-worker-script.spec
+++ b/packaging/rhc-worker-script.spec
@@ -15,15 +15,10 @@
 %{!?_root_sysconfdir:%global _root_sysconfdir %{_sysconfdir}}
 %global rhc_worker_conf_dir %{_root_sysconfdir}/rhc/workers
 
-# Go toolset configuration
-%global go_toolset_version 1.21
-
 # EL7 doesn't define go_arches (it is available in go-srpm-macros which is EL8+)
 %if !%{defined go_arches}
 %define go_arches x86_64
 %endif
-
-%global use_go_toolset_1_21 0%{?rhel} == 7 && !%{defined centos}
 
 Name:           %{repo_name}
 Version:        0.9
@@ -35,12 +30,8 @@ URL:            https://github.com/%{repo_orgname}/%{repo_name}
 Source0:        %{url}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 ExclusiveArch:  %{go_arches}
 
-BuildRequires: git
-%if %{use_go_toolset_1_21}
-BuildRequires:  go-toolset-%{go_toolset_version}-golang
-%else
+BuildRequires:  git
 BuildRequires:  golang
-%endif
 Requires:       rhc
 
 %description
@@ -55,11 +46,7 @@ export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2 -fstack-protector-all"
 export BUILDFLAGS="%{buildflags}"
 export LDFLAGS="%{goldflags}"
 
-%if %{use_go_toolset_1_21}
-scl enable go-toolset-%{go_toolset_version} -- make build
-%else
 make build
-%endif
 
 %install
 # Create a temporary directory /var/lib/rhc-worker-script - used mainly for storing temporary files


### PR DESCRIPTION
Since we are building with a new buildroot that contains go 1.21, we don't require the scl workarounds anymore. We can just use plain golang in the BuildRequires and the normal make build.